### PR TITLE
fix for dictionary ordering issue with commandline script

### DIFF
--- a/chaste_codegen/_command_line_script.py
+++ b/chaste_codegen/_command_line_script.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 
 def chaste_codegen():
     # Link names to classes for converting code
-    translators = OrderedDict({'Chaste': cg.NormalChasteModel, 'ChasteOpt': cg.OptChasteModel})
+    translators = OrderedDict([('Chaste', cg.NormalChasteModel), ('ChasteOpt', cg.OptChasteModel)])
     # Store extensions we can use and how to use them, based on extension of given outfile
     extension_lookup = {'Chaste': dict(), 'ChasteOpt': dict()}
     for key in ('.cpp', '.hpp', '.cellml', ''):


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This should fix issues on python 3.5 with the ordering of the dictionary used in the commandline scipt

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
was getting intermittend tests fail for python 3.5

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.
n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

