### PR TITLE
Updated travis URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![travis](https://travis-ci.org/ModellingWebLab/chaste-codegen.svg?branch=master)](https://travis-ci.org/ModellingWebLab/chaste-codegen)
+[![travis](https://travis-ci.com/ModellingWebLab/chaste-codegen.svg?branch=master)](https://travis-ci.com/ModellingWebLab/chaste-codegen)
 [![codecov](https://codecov.io/gh/ModellingWebLab/chaste-codegen/branch/master/graph/badge.svg)](https://codecov.io/gh/ModellingWebLab/chaste-codegen)
 
 # Code generation for cardiac Chaste
@@ -16,7 +16,7 @@ Please see [CONTRIBUTING.md](CONTRIBUTING.md) for the developer installation ins
 
 ## Using `chaste_codegen`
 
-To generate code for the Web Lab:
+To generate code for Chaste:
 
 ```
 # Select a path to write the output to


### PR DESCRIPTION
From .org to .com

Second version, to see if the webhooks for .org are gone