### PR TITLE
Only calculate jacobian if we're also outputting it

### DIFF
--- a/chaste_codegen/cvode_chaste_model.py
+++ b/chaste_codegen/cvode_chaste_model.py
@@ -10,9 +10,12 @@ class CvodeChasteModel(cg.ChasteModel):
     def __init__(self, model, file_name, **kwargs):
         super().__init__(model, file_name, **kwargs)
         self._use_analytic_jacobian = kwargs.get('use_analytic_jacobian', False)  # store if jacobians are needed
-        self._jacobian_equations, self._jacobian_matrix = self._get_jacobian()
-        self._formatted_state_vars = self._update_state_vars()
-        self._formatted_jacobian_equations, self._formatted_jacobian_matrix_entries = self._format_jacobian()
+        self._formatted_jacobian_equations = []
+        self._formatted_jacobian_matrix_entries = sp.Matrix()
+        if self._use_analytic_jacobian:
+            self._jacobian_equations, self._jacobian_matrix = self._get_jacobian()
+            self._formatted_state_vars = self._update_state_vars()
+            self._formatted_jacobian_equations, self._formatted_jacobian_matrix_entries = self._format_jacobian()
 
     def _print_modifiable_parameters(self, symbol):
         return 'NV_Ith_S(mParameters, ' + str(self._modifiable_parameters.index(symbol)) + ')'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I've added a check to exclude the calculation of jacobians where they don't appear in the output

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Increased performance for cvode models without jacobian

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.
n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

