### PR TITLE
changed to from_units= to_units= in prep for cellmlmanip changes

### DIFF
--- a/chaste_codegen/chaste_model.py
+++ b/chaste_codegen/chaste_model.py
@@ -218,7 +218,6 @@ class ChasteModel(object):
         if var in self._state_vars:
             initial_value = getattr(var, 'initial_value', None)
         else:
-            print(var)
             eqs = self._model.get_equations_for([var])
             # If there is a defining equation, there should be just 1 equation and it should be of the form var = value
             if len(eqs) == 1 and isinstance(eqs[0].rhs, sp.numbers.Float):
@@ -308,16 +307,10 @@ class ChasteModel(object):
     def _get_modifiable_parameters_exposed(self):
         """ Get the variables in the model that have exposed annotation and are modifiable parameters
             (irrespective of any modifiable_parameters tags)"""
-#        return [q for q in self._model.variables()
-#                if self._model.has_ontology_annotation(q, self._OXMETA)
-#                and not self._model.get_ontology_terms_by_variable(q, self._OXMETA)[-1]
-#                .startswith('membrane_stimulus_current')
-#                and q not in self._model.get_derived_quantities()
-#                and q not in self._model.get_state_variables()
-#                and not q == self._time_variable]
         return [q for q in self._model.variables()
                 if self._model.has_ontology_annotation(q, self._OXMETA)
-                and not self._model.get_ontology_terms_by_variable(q, self._OXMETA)[-1] == 'membrane_stimulus_current'
+                and not self._model.get_ontology_terms_by_variable(q, self._OXMETA)[-1]
+                .startswith('membrane_stimulus_current')
                 and q not in self._model.get_derived_quantities()
                 and q not in self._model.get_state_variables()
                 and not q == self._time_variable]


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed get_conversion_factor calls to explicitly setting to_unit and from_unit in preperation of cellmlmanip changes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

More robust in the face of potential order changes in cellmlamnip function definition

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

anticipation on cellmlmanip

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

