### PR TITLE
moving parameters to 1 places in the set of templates

### DIFF
--- a/chaste_codegen/templates/BE/cpp/constructor
+++ b/chaste_codegen/templates/BE/cpp/constructor
@@ -11,6 +11,5 @@
 
         // We have a default stimulus specified in the CellML file metadata
         this->mHasDefaultStimulusFromCellML = true;{%- endif %}
-        {% for param in modifiable_parameters %}
-        this->mParameters[{{loop.index0}}] = {{param["initial_value"]}}; // ({{param["comment_name"]}}) [{{param["units"]}}]{%- endfor %}
+{% include "Shared/cpp/parameters" %}
     }

--- a/chaste_codegen/templates/Cvode/cpp/constructor
+++ b/chaste_codegen/templates/Cvode/cpp/constructor
@@ -15,6 +15,5 @@
         this->mHasDefaultStimulusFromCellML = true;{%- endif %}{%- if jacobian_equations|length > 0 %}
         mUseAnalyticJacobian = true;
         mHasAnalyticJacobian = true;{%- endif %}
-        {% for param in modifiable_parameters %}
-        NV_Ith_S(this->mParameters, {{loop.index0}}) = {{param["initial_value"]}}; // ({{param["comment_name"]}}) [{{param["units"]}}]{%- endfor %}
+{% with %}{% set is_cvode = True %}{% include "Shared/cpp/parameters" %}{% endwith %}
     }

--- a/chaste_codegen/templates/Normal/cpp/constructor
+++ b/chaste_codegen/templates/Normal/cpp/constructor
@@ -12,6 +12,5 @@
 
         // We have a default stimulus specified in the CellML file metadata
         this->mHasDefaultStimulusFromCellML = true;{%- endif %}
-        {% for param in modifiable_parameters %}
-        this->mParameters[{{loop.index0}}] = {{param["initial_value"]}}; // ({{param["comment_name"]}}) [{{param["units"]}}]{%- endfor %}
+{% include "Shared/cpp/parameters" %}
     }

--- a/chaste_codegen/templates/RL/cpp/constructor
+++ b/chaste_codegen/templates/RL/cpp/constructor
@@ -11,6 +11,5 @@
 
         // We have a default stimulus specified in the CellML file metadata
         this->mHasDefaultStimulusFromCellML = true;{%- endif %}
-        {% for param in modifiable_parameters %}
-        this->mParameters[{{loop.index0}}] = {{param["initial_value"]}}; // ({{param["comment_name"]}}) [{{param["units"]}}]{%- endfor %}
+{% include "Shared/cpp/parameters" %}
     }

--- a/chaste_codegen/templates/Shared/cpp/parameters
+++ b/chaste_codegen/templates/Shared/cpp/parameters
@@ -1,0 +1,2 @@
+        {% for param in modifiable_parameters %}
+        {% if is_cvode is defined and is_cvode %}NV_Ith_S(this->mParameters, {{loop.index0}}){% else %}this->mParameters[{{loop.index0}}]{% endif %} = {{param["initial_value"]}}; // ({{param["comment_name"]}}) [{{param["units"]}}]{%- endfor %}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Moved modifiable parameters to only 1 place within the sets of templates

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Will make it easier to add modifiers as it'll have to only be in one place

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

template rerangement

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

n/a

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

