### PR TITLE
Fixed sympy deprectaion warning when using sympy 1.7

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,5 @@
 # (unreleased)
-- Fixed sympy deprectaion warning when using sympy 1.7
+- Fixed sympy deprecation warning when using sympy 1.7
 - Improved support for secondary trigonometric functions such as sec and acoth.
 - When used with Cellmlmanip version 0.2.2+ an improved printing of devisions is used. For example `1 / (1/cos(x))` now gets rendered as `cos(x)` whereas previously it would be `1 / 1 / cos(x)` giving the incorrect result. An side effcet of the change is that powers of formulas get extra brackets e.g. `pow((1 / x), 2)`.
 - chaste_codegen uses placeholder functions for some common maths functions like exp, in order to delay evaluation till the point where the code is written. For programmers using chaste_codegen as a library, there now is a function called `subs_math_func_placeholders` which can be used on any sympy expression to substitute these placeholders.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,5 @@
 # (unreleased)
+- Fixed sympy deprectaion warning when using sympy 1.7
 - Improved support for secondary trigonometric functions such as sec and acoth.
 - When used with Cellmlmanip version 0.2.2+ an improved printing of devisions is used. For example `1 / (1/cos(x))` now gets rendered as `cos(x)` whereas previously it would be `1 / 1 / cos(x)` giving the incorrect result. An side effcet of the change is that powers of formulas get extra brackets e.g. `pow((1 / x), 2)`.
 - chaste_codegen uses placeholder functions for some common maths functions like exp, in order to delay evaluation till the point where the code is written. For programmers using chaste_codegen as a library, there now is a function called `subs_math_func_placeholders` which can be used on any sympy expression to substitute these placeholders.

--- a/chaste_codegen/_chaste_printer.py
+++ b/chaste_codegen/_chaste_printer.py
@@ -6,7 +6,7 @@ from sympy import (
     S,
 )
 from sympy.core.mul import _keep_coeff
-from sympy.printing.cxxcode import cxxcode
+from sympy.printing import cxxcode
 from sympy.printing.precedence import precedence
 
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
fixes #181 as reported by @mirams 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
These warnings would show up during a chaste build. And that is annoying and erode confedence in the software

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [X] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->
I tested with both sympy 1.7, 1.6.1 and 1.6.2 
