### PR TITLE
Update setup.py

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,6 @@
+# Release 0.9.11
+- Pinned Pint version to be > 0.9 and < 0.20 since 0.20 has changed the location and number of arguments of the ScaleConverter and UnitDefinition classes.
+
 # Release 0.9.10
 - Added support for Sundials 6.0.0 which requires a newly introduced SUNContext object. This version of chaste_codegen now generates code that will work with Sundials 6.0, but is backwards compatible with previous Sundials versions and the 2021 release of Chaste.
 

--- a/chaste_codegen/_config.py
+++ b/chaste_codegen/_config.py
@@ -19,7 +19,7 @@ try:
 finally:
     # Always manually delete frame
     # https://docs.python.org/2/library/inspect.html#the-interpreter-stack
-    del(frame)
+    del frame
 
 # Template sub-directory
 TEMPLATE_SUBDIR = os.path.join('templates')
@@ -31,7 +31,7 @@ DATA_DIR = os.path.join(MODULE_DIR, 'data')
 logging.basicConfig()
 LOGGER = logging.getLogger('chaste_codegen')
 LOGGER.setLevel(logging.INFO)
-del(logging)
+del logging
 
 #
 # Version info

--- a/chaste_codegen/model_with_conversions.py
+++ b/chaste_codegen/model_with_conversions.py
@@ -347,7 +347,7 @@ def _get_stimulus(model, skip_chaste_stimulus_conversion):
         except TypeError as e:
             if str(e) == "unsupported operand type(s) for /: 'HeartConfig::Instance()->GetCapacitance' and 'NoneType'":
                 e = CodegenError("Membrane capacitance is required to be able to apply conversion to stimulus current!")
-            raise(e)
+            raise e
 
         return_stim_eqs = get_equations_for(model, stim_params, filter_modifiable_parameters_lhs=False)
     return stim_params | stim_params_orig, return_stim_eqs

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'mpmath>=1.1.0, <2',
         'networkx>=2.4, <3',
         'packaging>=20.4, <21',
-        'Pint>=0.9, <0.20',
+        'Pint>=0.9, <1',
         'pyparsing>=2.4.7, <3',
         'rdflib>=5.0.0, <7',
         'six>=1.15.0, <2',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         'mpmath>=1.1.0, <2',
         'networkx>=2.4, <3',
         'packaging>=20.4, <21',
-        'Pint>=0.9, <1',
+        'Pint>=0.9, <0.20',
         'pyparsing>=2.4.7, <3',
         'rdflib>=5.0.0, <7',
         'six>=1.15.0, <2',

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'sympy>=1.9, <1.11',
         'zipp>=1.2.0, <2',
         'Jinja2>=2.11.3, <3',
-        'cellmlmanip>=0.3.4, <0.4',
+        'cellmlmanip>=0.3.5, <0.4',
         'Jinja2>=2.11.3, <3',
     ],
     extras_require={


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Pinned Pint version to be > 0.9 and < 0.20 since 0.20 has changed the location and number of arguments of the ScaleConverter and UnitDefinition classes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Otherwise python 3.10 will pull in an incompatible Pint version

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [X] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).
- [ ] I have updated version & citation.txt & citation.cff version.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

