### PR TITLE
Fix CI for Python 3.6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         submodules: recursive
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* This PR supports #265 
* It updates the CI workflow to use the latest version of the [setup-python](https://github.com/actions/setup-python) action which can fetch Python versions that don't come pre-installed on github runners ([setup-actions changelog](https://github.blog/changelog/2020-04-30-github-actions-v2-setup-python-action)).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
* Tests failed for PR #264 because Python 3.6 had been removed from github runners.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Documentation checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation in the code where necessary.
- [ ] I have checked spelling in all (new) comments and documentation.
- [ ] I have added a note to RELEASE.md if relevant (new feature, breaking change, or notable bug fix).
- [ ] I have updated version & citation.txt & citation.cff version.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested)-->

